### PR TITLE
ci: make it build all branches, tweak flake.lock updater

### DIFF
--- a/.github/workflows/build-and-cache.yaml
+++ b/.github/workflows/build-and-cache.yaml
@@ -1,10 +1,6 @@
 name: Build & Cache flake outputs
 
-on:
-  push:
-    branches:
-        - flakes
-        - update_flake_lock_action
+on: push
 
 jobs:
   build-and-cache:

--- a/.github/workflows/update-flake.yaml
+++ b/.github/workflows/update-flake.yaml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          ref: main
 
       - name: Set up Nix
         uses: DeterminateSystems/nix-installer-action@main
@@ -18,3 +20,10 @@ jobs:
         uses: DeterminateSystems/update-flake-lock@v24
         with:
           token: ${{ secrets.FLAKE_LOCK_PAT }}
+          branch: flake-update
+          commit-msg: "flake.lock: update"
+          pr-title: "flake.lock: update"
+          pr-body: |
+            ```
+            {{ env.GIT_COMMIT_MESSAGE }}
+            ```


### PR DESCRIPTION
## Build & Cache Workflow
### Before
It would be triggered by a `push` to `flakes` or `update_flake_lock_action`.
### After
It would be triggered by a `push` to any branch.
### Why
Both branches that were previously explicilty referenced are now renamed.
This is not likely to happen again, but updating these references is extra maintenance.
**With this change, any other branch (like a feature branch) would be built and cached too, which is also a desired behaviour.**

## Update flake.lock Workflow
### Before
It would run against the default branch when triggered by `schedule`.
When triggered manually (`workflow_dispatch`), it would run against the chosen branch.
The commit message and PR title/body sucked ass.
### After
It would always run against the `main` branch.
The commit message and PR title/body don't suck ass.
### Why
We don't want to accidentally make the workflow run against the wrong branch, hence the explicit reference here.
We don't want the commit message and PR title/body to suck ass.