### PR TITLE
add nix-vscode-extensions; add esphome

### DIFF
--- a/common/default.nix
+++ b/common/default.nix
@@ -41,6 +41,7 @@
 
   # overlays
   nixpkgs.overlays = [
+    inputs.nix-vscode-extensions.overlays.default
     (import (inputs.self + /pkgs))
   ];
 }

--- a/common/x86_64-linux/default.nix
+++ b/common/x86_64-linux/default.nix
@@ -55,6 +55,7 @@ in
     nixd
     dotnet-sdk
     dotnet-runtime
+    unstable.esphome
     (vscode-with-extensions.override {
       vscodeExtensions =
         with vscode-marketplace;
@@ -64,6 +65,7 @@ in
           ms-dotnettools.vscode-dotnet-runtime
           jnoortheen.nix-ide
           ms-vsliveshare.vsliveshare
+          esphome.esphome-vscode
         ];
     })
 

--- a/common/x86_64-linux/default.nix
+++ b/common/x86_64-linux/default.nix
@@ -56,12 +56,15 @@ in
     dotnet-sdk
     dotnet-runtime
     (vscode-with-extensions.override {
-      vscodeExtensions = with vscode-extensions; [
-        ms-dotnettools.csharp
-        ms-dotnettools.vscode-dotnet-runtime
-        jnoortheen.nix-ide
-        ms-vsliveshare.vsliveshare
-      ];
+      vscodeExtensions =
+        with vscode-marketplace;
+        with vscode-extensions;
+        [
+          ms-dotnettools.csharp
+          ms-dotnettools.vscode-dotnet-runtime
+          jnoortheen.nix-ide
+          ms-vsliveshare.vsliveshare
+        ];
     })
 
     # apps

--- a/flake.lock
+++ b/flake.lock
@@ -114,6 +114,24 @@
         "type": "github"
       }
     },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "gitignore": {
       "inputs": {
         "nixpkgs": [
@@ -303,6 +321,27 @@
         "type": "github"
       }
     },
+    "nix-vscode-extensions": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750039657,
+        "narHash": "sha256-Vrh5PDskpJ2kEumHbncffZxWQGr2pK88oTOFtBUWG74=",
+        "owner": "nix-community",
+        "repo": "nix-vscode-extensions",
+        "rev": "54ce2a0e930383535c632aad39b22205fa430be0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nix-vscode-extensions",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1747953325,
@@ -389,6 +428,7 @@
         "nix-homebrew": "nix-homebrew",
         "nix-index-database": "nix-index-database",
         "nix-unstable": "nix-unstable",
+        "nix-vscode-extensions": "nix-vscode-extensions",
         "nixpkgs": "nixpkgs_2"
       }
     },
@@ -414,6 +454,21 @@
       }
     },
     "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,11 @@
       url = "github:ryantm/agenix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    nix-vscode-extensions = {
+      url = "github:nix-community/nix-vscode-extensions";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
   outputs =
     inputs:


### PR DESCRIPTION
This PR adds [nix-vscode-extensions](https://github.com/nix-community/nix-vscode-extensions) to the flake and to the nixpkgs overlays.

This allows to install any extensions from the VSCode Marketplace even if they are not in nixpkgs, using the `vscode-marketplace` attrset of nixpkgs.

I've added a `with` clause to make it easier, but keep in mind that since there are two `with`s in there, the last one takes priority. So if an extension is present in nixpkgs, the package from the `vscode-extensions` attrset will be used. If it's not there, it will be taken from `vscode-marketplace` (provided by the `nix-vscode-extensions` overlay).

Please **rebase**-merge this, as the PR also adds esphome tooling and the esphome VSCode extension.